### PR TITLE
feat: add `grype` and `syft`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ llvmPackages_14.stdenv.mkDerivation {
     docker
     git
     go
+    grype
     just
     k3d
     kind
@@ -30,6 +31,7 @@ llvmPackages_14.stdenv.mkDerivation {
     shellcheck
     stdenv
     step-cli
+    syft
     yq-go
     # vscode
   ] ++ lib.optional stdenv.isDarwin [ Security libiconv ];


### PR DESCRIPTION
these are command-line utilities that may be used to scan docker images for vulnerabilities.