### PR TITLE
feat: a hook for `dev/bin` utilities

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,6 +38,17 @@ llvmPackages_14.stdenv.mkDerivation {
   ] ++ lib.optional stdenv.isDarwin [ Security libiconv ];
 
   shellHook = ''
+    # adds the `just-*` dev utilities to the path, if a path to linkerd/dev
+    # is provided. by default this will not be included, but these utilities can
+    # be included by calling:
+    # ```
+    # LINKERD_DEV="/some/path" nix-shell shell.nix
+    # ```
+    if [[ $LINKERD_DEV != "" ]];
+    then
+      export PATH="$PATH:$LINKERD_DEV/bin"
+    fi
+
     # set up a shorter alias for kubectl.
     alias k="kubectl"
 


### PR DESCRIPTION
the `dev` repository contains a `bin/` directory with various justfiles referred to by the linkerd2-proxy's own justfile.

for example, building a proxy image via `just docker` will fail without this in the path because it depends on `just-cargo`.

this commit introduces a conditional expression so that the `bin/` directory is added to the path if an environment variable exists.

this shell can now be called by running a command like:

```
LINKERD_DEV="/some/path" nix-shell shell.nix
```