### PR TITLE
feat: Add more dependencies for `linkerd2-proxy` and `linkerd2`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,12 +12,17 @@ llvmPackages_14.stdenv.mkDerivation {
     bashInteractive
     binutils
     cacert
+    cargo-deny
+    cargo-nextest
     cmake
     direnv
     docker
     git
     go
+    golangci-lint
+    gotestsum
     grype
+    jq
     just
     k3d
     kind


### PR DESCRIPTION
This adds the following deps:
- `jq`: Broadly useful for parsing json
- `cargo-deny`: For locally testing cargo deny configs
- `cargo-nextest`: Faster test runner, supported by `linkerd2-proxy` and `linkerd2` justfiles
- `golanci-lint`/`gotestsum`: Used by `linkerd2` justfiles for go tests/lints